### PR TITLE
bump version to v3.1.1 + add a couple more extensions to sync with R v3.1.0 easyconfig

### DIFF
--- a/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
+++ b/easybuild/easyconfigs/r/R/R-3.1.1-intel-2014b.eb
@@ -1,5 +1,5 @@
 name = 'R'
-version = '3.1.0'
+version = '3.1.1'
 
 homepage = 'http://www.r-project.org/'
 description = """R is a free software environment for statistical computing and graphics."""
@@ -18,7 +18,7 @@ dependencies = [
     ('libreadline', '6.3'),
     ('ncurses', '5.9'),
     ('libpng', '1.6.12'),  # for plotting in R
-    ('libjpeg-turbo', '1.3.1'), # for plottting in R
+    ('libjpeg-turbo', '1.3.1'),  # for plottting in R
     ('Java', '1.7.0_60', '', True),  # Java bindings are built if Java is found, might as well provide it
 ]
 
@@ -36,7 +36,7 @@ name_tmpl = '%(name)s_%(version)s.tar.gz'
 ext_options = {
     'source_urls': [
         'http://cran.r-project.org/src/contrib/Archive/%(name)s',  # package archive
-        'http://cran.freestatistics.org/src/contrib'  # alternative for packages
+        'http://cran.freestatistics.org/src/contrib',  # alternative for packages
     ],
     'source_tmpl': name_tmpl,
 }
@@ -46,7 +46,7 @@ bioconductor_options = {
     'source_tmpl': name_tmpl,
 }
 # !! order of packages is important !!
-# Packages updated on 30 JUNE 2014
+# packages updated on June 30th 2014
 exts_list = [
     # default libraries, only here to sanity check their presence
     'base',
@@ -308,6 +308,15 @@ exts_list = [
     ('Mcomp', '2.05', ext_options),
     ('ipred', '0.9-3', ext_options),
     ('knitr', '1.6', ext_options),
+    ('statmod', '1.4.20', ext_options),
+    ('mlogit', '0.2-4', ext_options),
+    ('gdsfmt', '1.0.4', ext_options),
+    ('SNPRelate', '0.9.19', ext_options),
+    ('getopt', '1.20.0', ext_options),
+    ('miscTools', '0.6-16', ext_options),
+    ('maxLik', '1.2-0', ext_options),
+    ('gsalib', '2.0', ext_options),
+    ('reshape', '0.8.5', ext_options),
 ]
 
 moduleclass = 'lang'


### PR DESCRIPTION
@hajgato: syncing up both PRs proved to be very painful because you've reordered the extensions, and also because of dependency updates (libpng, which includes a zlib update, causing conflicts with other stuff in flight on my end)

But, there's another option: just bumping the R version to v3.1.1! :)

I also added the missing extensions I have in https://github.com/hpcugent/easybuild-easyconfigs/pull/908.
