### PR TITLE
update crc-blast easyconfig 

### DIFF
--- a/easybuild/easyconfigs/c/crb-blast/crb-blast-0.6.9-intel-2017a-Ruby-2.3.4.eb
+++ b/easybuild/easyconfigs/c/crb-blast/crb-blast-0.6.9-intel-2017a-Ruby-2.3.4.eb
@@ -3,22 +3,19 @@ easyblock = 'Bundle'
 name = 'crb-blast'
 version = '0.6.9'
 
-rubyver = '2.3.4'
-versionsuffix = '-Ruby-%s' % rubyver
-
 homepage = 'https://github.com/cboursnell/crb-blast'
 description = """Conditional Reciprocal Best BLAST - high confidence ortholog assignment.
  CRB-BLAST is a novel method for finding orthologs between one set of sequences and another.
  This is particularly useful in genome and transcriptome annotation."""
 
-toolchain = {'name': 'intel', 'version': '2017a'}
+toolchain = {'name': 'intel', 'version': '2017b'}
 
 dependencies = [
-    ('Ruby', rubyver, '', True),
-    ('BLAST+', '2.6.0', '-Python-2.7.13'),
+    ('Ruby', '2.5.0'),
+    ('BLAST+', '2.7.1', '-Python-2.7.14'),
 ]
 
-ext_options = {
+exts_default_options = {
     'source_urls': ['http://rubygems.org/downloads/'],
     'source_tmpl': '%(name)s-%(version)s.gem',
 }
@@ -27,27 +24,35 @@ ext_options = {
 exts_defaultclass = 'RubyGem'
 
 exts_list = [
-    ('facade', '1.0.7', dict(ext_options.items() + [
-        ('checksums', ['2d33a1d839785fcb56b7da97e8aeef81b44474f927f8234c90ea18201eab597d'])])),
-    ('pathname2', '1.8.0', dict(ext_options.items() + [
-        ('checksums', ['3a315689d0f183409504bd4949d188e28559d7b8f61960c36b332481e2443472'])])),
-    ('fixwhich', '1.0.2', dict(ext_options.items() + [
-        ('checksums', ['c6a8f796a7eb60ffbc29f0d2af85461761a36c2864d25e445ff18bfbd1657078'])])),
-    ('bindeps', '1.2.1', dict(ext_options.items() + [
-        ('checksums', ['3c11d75aa722bed67246852bb430a182361a128910d384b664b91f3e65bc34b5'])])),
-    ('threach', '0.2.0', dict(ext_options.items() + [
-        ('checksums', ['432cbf3569bf9b09e26f93d0959fd6fb911c71e790e8a4cc4d1110e139a2ffca'])])),
-    ('bio', '1.5.1', dict(ext_options.items() + [
-        ('checksums', ['896c19af7e724e038baceae20c00688872b70c69ef966ef3adc42696d001b441'])])),
-    ('trollop', '2.1.2', dict(ext_options.items() + [
-        ('checksums', ['88422e8137b1e635ed07f6b8480c2c2a16d3ac1288023688c4da20d786f12510'])])),
-    (name, version, dict(ext_options.items() + [
-        ('checksums', ['69c346e7d83efe9b9a383a39b57e7cce186a82b7074f275b14906f8f05678e3e'])])),
+    ('facade', '1.0.7', {
+        'checksums': ['2d33a1d839785fcb56b7da97e8aeef81b44474f927f8234c90ea18201eab597d'],
+    }),
+    ('pathname2', '1.8.0', {
+        'checksums': ['3a315689d0f183409504bd4949d188e28559d7b8f61960c36b332481e2443472'],
+    }),
+    ('fixwhich', '1.0.2', {
+        'checksums': ['c6a8f796a7eb60ffbc29f0d2af85461761a36c2864d25e445ff18bfbd1657078'],
+    }),
+    ('bindeps', '1.2.1', {
+        'checksums': ['3c11d75aa722bed67246852bb430a182361a128910d384b664b91f3e65bc34b5'],
+    }),
+    ('threach', '0.2.0', {
+        'checksums': ['432cbf3569bf9b09e26f93d0959fd6fb911c71e790e8a4cc4d1110e139a2ffca'],
+    }),
+    ('bio', '1.5.1', {
+        'checksums': ['896c19af7e724e038baceae20c00688872b70c69ef966ef3adc42696d001b441'],
+    }),
+    ('trollop', '2.1.2', {
+        'checksums': ['88422e8137b1e635ed07f6b8480c2c2a16d3ac1288023688c4da20d786f12510'],
+    }),
+    (name, version, {
+        'checksums': ['69c346e7d83efe9b9a383a39b57e7cce186a82b7074f275b14906f8f05678e3e'],
+    }),
 ]
 
 sanity_check_paths = {
-    'files': ['bin/%s' % x for x in ['bioruby', 'br_biofetch.rb', 'br_bioflat.rb', 'br_biogetseq.rb', 'br_pmfetch.rb',
-                                     'crb-blast']],
+    'files': ['bin/bioruby', 'bin/br_biofetch.rb', 'bin/br_bioflat.rb', 'bin/br_biogetseq.rb',
+              'bin/br_pmfetch.rb', 'bin/crb-blast'],
     'dirs': ['gems'],
 }
 


### PR DESCRIPTION
@hajgato for https://github.com/easybuilders/easybuild-easyconfigs/pull/5124

* bump to `intel/2017b`
* update to Ruby 2.5.0 (requires https://github.com/easybuilders/easybuild-easyconfigs/pull/5573)
* update to BLAST+ 2.7.1
* drop versionsuffix
* leverage `exts_default_options`